### PR TITLE
Se crea una version base de auth, y el acceso por roles a informacion

### DIFF
--- a/internal/clients/prediagnostic_client.go
+++ b/internal/clients/prediagnostic_client.go
@@ -57,3 +57,42 @@ func (c *PreDiagnosticClient) GetPreDiagnostic(id string) (map[string]interface{
 
 	return result, nil
 }
+
+// GetCases obtiene todos los casos del servicio de prediagnóstico
+func (c *PreDiagnosticClient) GetCases() ([]map[string]interface{}, error) {
+	url := fmt.Sprintf("%s/prediagnostic/cases", c.BaseURL)
+
+	resp, err := http.Get(url)
+	if err != nil {
+		fmt.Printf("Error en la petición HTTP para obtener casos: %v\n", err)
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	// Verificar el código de estado
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("respuesta HTTP %d: %s", resp.StatusCode, resp.Status)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Printf("Error leyendo el body de casos: %v\n", err)
+		return nil, err
+	}
+
+	// Debug: Mostrar el contenido de la respuesta
+	fmt.Printf("Respuesta de casos del servidor: %s\n", string(body))
+
+	// Verificar si el body está vacío
+	if len(body) == 0 {
+		return nil, fmt.Errorf("respuesta vacía del servidor")
+	}
+
+	var result []map[string]interface{}
+	if err := json.Unmarshal(body, &result); err != nil {
+		fmt.Printf("Error parseando JSON de casos: %v\n", err)
+		return nil, fmt.Errorf("error parseando JSON de casos: %w", err)
+	}
+
+	return result, nil
+}

--- a/internal/graph/model/models_gen.go
+++ b/internal/graph/model/models_gen.go
@@ -2,6 +2,18 @@
 
 package model
 
+type Case struct {
+	ID              string            `json:"id"`
+	PacienteID      string            `json:"pacienteId"`
+	PacienteNombre  string            `json:"pacienteNombre"`
+	PacienteEmail   string            `json:"pacienteEmail"`
+	FechaSubida     string            `json:"fechaSubida"`
+	Estado          string            `json:"estado"`
+	URLRadiografia  string            `json:"urlRadiografia"`
+	Resultados      *ResultadosModelo `json:"resultados"`
+	DoctorAsignado  *string           `json:"doctorAsignado"`
+}
+
 type PreDiagnostic struct {
 	PrediagnosticID  string            `json:"prediagnostic_id"`
 	PacienteID       string            `json:"pacienteId"`

--- a/internal/graph/resolver.go
+++ b/internal/graph/resolver.go
@@ -9,4 +9,6 @@ import (
 
 type Resolver struct {
 	PrediagnosticSrv *services.PreDiagnosticService
+	CaseSrv          *services.CaseService
+	AuthSrv          *services.AuthService
 }

--- a/internal/graph/schema.graphqls
+++ b/internal/graph/schema.graphqls
@@ -13,6 +13,19 @@ type ResultadosModelo{
     fechaProcesamiento:String!
 }
 
+type Case {
+    id: ID!
+    pacienteId: ID!
+    pacienteNombre: String!
+    pacienteEmail: String!
+    fechaSubida: String!
+    estado: String!
+    urlRadiografia: String!
+    resultados: ResultadosModelo
+    doctorAsignado: String
+}
+
 type Query{
     getPreDiagnostic(id:ID!):PreDiagnostic
+    getCases: [Case!]!
 }

--- a/internal/services/auth_service.go
+++ b/internal/services/auth_service.go
@@ -1,1 +1,77 @@
 package services
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+type AuthService struct {
+	// En un escenario real, aquí tendrías configuración para validar JWT
+	// Por ahora implementamos una validación básica
+}
+
+type UserClaims struct {
+	UserID string
+	Email  string
+	Role   string
+}
+
+func NewAuthService() *AuthService {
+	return &AuthService{}
+}
+
+// ValidateTokenAndRole valida el token de autorización y verifica el rol
+func (s *AuthService) ValidateTokenAndRole(ctx context.Context, authHeader string, requiredRole string) (*UserClaims, error) {
+	if authHeader == "" {
+		return nil, errors.New("token de autorización requerido")
+	}
+
+	// Extraer el token del header "Bearer <token>"
+	parts := strings.Split(authHeader, " ")
+	if len(parts) != 2 || parts[0] != "Bearer" {
+		return nil, errors.New("formato de token inválido")
+	}
+
+	token := parts[1]
+	
+	// En un escenario real, aquí validarías el JWT contra tu servicio de auth
+	// Por ahora implementamos una validación mock
+	userClaims, err := s.validateJWT(token)
+	if err != nil {
+		return nil, fmt.Errorf("token inválido: %w", err)
+	}
+
+	// Verificar rol
+	if userClaims.Role != requiredRole {
+		return nil, fmt.Errorf("acceso denegado: se requiere rol %s, pero el usuario tiene rol %s", 
+			requiredRole, userClaims.Role)
+	}
+
+	return userClaims, nil
+}
+
+// validateJWT - Mock implementation. En producción usarías una librería JWT real
+func (s *AuthService) validateJWT(token string) (*UserClaims, error) {
+	// Mock validation - en producción aquí validarías el token real
+	// y extraerías los claims del JWT
+	
+	// Para testing, aceptamos tokens con formato específico
+	switch token {
+	case "doctor_token_123":
+		return &UserClaims{
+			UserID: "doctor_1",
+			Email:  "doctor@hospital.com",
+			Role:   "doctor",
+		}, nil
+	case "patient_token_456":
+		return &UserClaims{
+			UserID: "patient_1", 
+			Email:  "patient@email.com",
+			Role:   "patient",
+		}, nil
+	default:
+		return nil, errors.New("token no válido")
+	}
+}

--- a/internal/services/case_service.go
+++ b/internal/services/case_service.go
@@ -1,1 +1,190 @@
 package services
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/unobeswarch/businesslogic/internal/clients"
+	"github.com/unobeswarch/businesslogic/internal/graph/model"
+)
+
+type CaseService struct {
+	prediagnosticClient *clients.PreDiagnosticClient
+}
+
+func NewCaseService(prediagnosticURL string) *CaseService {
+	return &CaseService{
+		prediagnosticClient: clients.NewPrediagnosticClient(prediagnosticURL),
+	}
+}
+
+// GetAllCases obtiene todos los casos y los procesa/estandariza
+func (s *CaseService) GetAllCases() ([]*model.Case, error) {
+	// Obtener datos raw del servicio prediagnostic
+	rawCases, err := s.prediagnosticClient.GetCases()
+	if err != nil {
+		return nil, fmt.Errorf("error obteniendo casos del servicio prediagnostic: %w", err)
+	}
+
+	// Procesar y estandarizar los datos
+	var cases []*model.Case
+	for _, rawCase := range rawCases {
+		processedCase, err := s.processAndStandardizeCase(rawCase)
+		if err != nil {
+			// Log error pero continúa procesando otros casos
+			fmt.Printf("Error procesando caso: %v\n", err)
+			continue
+		}
+		cases = append(cases, processedCase)
+	}
+
+	return cases, nil
+}
+
+// processAndStandardizeCase transforma los datos raw en formato legible y estandarizado
+func (s *CaseService) processAndStandardizeCase(rawCase map[string]interface{}) (*model.Case, error) {
+	// Extraer ID del caso
+	caseID, ok := rawCase["id"].(string)
+	if !ok {
+		if idFloat, isFloat := rawCase["id"].(float64); isFloat {
+			caseID = fmt.Sprintf("%.0f", idFloat)
+		} else {
+			return nil, fmt.Errorf("ID del caso no válido")
+		}
+	}
+
+	// Extraer ID del paciente
+	pacienteID, ok := rawCase["user_id"].(string)
+	if !ok {
+		if idFloat, isFloat := rawCase["user_id"].(float64); isFloat {
+			pacienteID = fmt.Sprintf("%.0f", idFloat)
+		} else {
+			return nil, fmt.Errorf("ID del paciente no válido")
+		}
+	}
+
+	// Extraer información del paciente
+	pacienteNombre := s.extractStringField(rawCase, "paciente_nombre", "Nombre no disponible")
+	pacienteEmail := s.extractStringField(rawCase, "paciente_email", "Email no disponible")
+
+	// Extraer fecha de subida y formatearla
+	fechaSubida := s.processDate(rawCase["fecha_subida"])
+
+	// Extraer y procesar estado
+	estado := s.processStatus(rawCase["estado"])
+
+	// Extraer URL de radiografía
+	urlRadiografia := s.extractStringField(rawCase, "radiografia_url", "")
+
+	// Extraer doctor asignado (puede ser nil)
+	doctorAsignado := s.extractStringField(rawCase, "doctor_asignado", "")
+
+	// Procesar resultados del modelo si existen
+	var resultados *model.ResultadosModelo
+	if resultadosRaw, exists := rawCase["resultado_modelo"]; exists && resultadosRaw != nil {
+		if resultadosMap, ok := resultadosRaw.(map[string]interface{}); ok {
+			resultados = &model.ResultadosModelo{
+				ProbNeumonia:       s.extractFloatField(resultadosMap, "probabilidad_neumonia"),
+				Etiqueta:          s.processLabel(resultadosMap["etiqueta"]),
+				FechaProcesamiento: s.processDate(rawCase["fecha_procesamiento"]),
+			}
+		}
+	}
+
+	return &model.Case{
+		ID:              caseID,
+		PacienteID:      pacienteID,
+		PacienteNombre:  pacienteNombre,
+		PacienteEmail:   pacienteEmail,
+		FechaSubida:     fechaSubida,
+		Estado:          estado,
+		URLRadiografia:  urlRadiografia,
+		Resultados:      resultados,
+		DoctorAsignado:  &doctorAsignado,
+	}, nil
+}
+
+// Funciones auxiliares para extraer y procesar campos
+
+func (s *CaseService) extractStringField(data map[string]interface{}, field string, defaultValue string) string {
+	if value, exists := data[field]; exists && value != nil {
+		if strValue, ok := value.(string); ok {
+			return strValue
+		}
+	}
+	return defaultValue
+}
+
+func (s *CaseService) extractFloatField(data map[string]interface{}, field string) float64 {
+	if value, exists := data[field]; exists && value != nil {
+		if floatValue, ok := value.(float64); ok {
+			return floatValue
+		}
+	}
+	return 0.0
+}
+
+func (s *CaseService) processDate(dateValue interface{}) string {
+	if dateValue == nil {
+		return "Fecha no disponible"
+	}
+
+	if dateStr, ok := dateValue.(string); ok {
+		// Intentar parsear y reformatear la fecha para hacerla más legible
+		if parsedTime, err := time.Parse(time.RFC3339, dateStr); err == nil {
+			return parsedTime.Format("02/01/2006 15:04")
+		}
+		// Si no se puede parsear, devolver tal como está
+		return dateStr
+	}
+
+	return "Fecha no disponible"
+}
+
+func (s *CaseService) processStatus(statusValue interface{}) string {
+	if statusValue == nil {
+		return "Estado desconocido"
+	}
+
+	if statusStr, ok := statusValue.(string); ok {
+		// Estandarizar estados a formato legible
+		switch statusStr {
+		case "pending":
+			return "Pendiente"
+		case "processing":
+			return "En procesamiento"
+		case "completed":
+			return "Completado"
+		case "error":
+			return "Error"
+		case "reviewed":
+			return "Revisado"
+		default:
+			return statusStr
+		}
+	}
+
+	return "Estado desconocido"
+}
+
+func (s *CaseService) processLabel(labelValue interface{}) string {
+	if labelValue == nil {
+		return "Sin clasificar"
+	}
+
+	if labelStr, ok := labelValue.(string); ok {
+		// Estandarizar etiquetas a formato legible
+		switch labelStr {
+		case "pneumonia":
+			return "Neumonía detectada"
+		case "normal":
+			return "Normal"
+		case "uncertain":
+			return "Resultado incierto"
+		default:
+			return labelStr
+		}
+	}
+
+	return "Sin clasificar"
+}


### PR DESCRIPTION
Esta implementación crea un endpoint GraphQL getCases que valida que solo doctores puedan acceder, obtiene todos los casos médicos del servicio de prediagnóstico, procesa y estandariza los datos (fechas legibles, estados traducidos), y devuelve la lista completa de casos con información del paciente y resultados de IA para detección de neumonía.